### PR TITLE
LFH-52 Sort grades, categories and crafts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.loofah</groupId>
 	<artifactId>graph-api</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>graph-api</name>
 	<description>A graph API for loofah</description>
 	<packaging>jar</packaging>

--- a/src/main/java/com/loofah/graph/api/services/CategoryService.java
+++ b/src/main/java/com/loofah/graph/api/services/CategoryService.java
@@ -8,25 +8,30 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 @Component
 public class CategoryService {
 
-    private DataRetriever dataRetriever;
+    private final DataRetriever dataRetriever;
 
     @Autowired
-    public CategoryService(DataRetriever dataRetriever) {
+    public CategoryService(final DataRetriever dataRetriever) {
         this.dataRetriever = dataRetriever;
     }
 
-    public Category getById(String id) {
-        return dataRetriever.getCategoryById(id).orElseThrow(() -> new DataNotFoundException("no category found with id ["+id+"]"));
+    public Category getById(final String id) {
+        return dataRetriever.getCategoryById(id).orElseThrow(() -> new DataNotFoundException("no category found with id [" + id + "]"));
     }
 
-    public Category getByTitle(String title) {
-        return dataRetriever.getCategoryByTitle(title).orElseThrow(() -> new DataNotFoundException("no category found with title ["+title+"]"));
+    public Category getByTitle(final String title) {
+        return dataRetriever.getCategoryByTitle(title).orElseThrow(() -> new DataNotFoundException("no category found with title [" + title + "]"));
     }
 
     public List<Category> getAll() {
-        return dataRetriever.getAllCategories();
+        return dataRetriever.getAllCategories()
+                .stream()
+                .sorted()
+                .collect(toList());
     }
 }

--- a/src/main/java/com/loofah/graph/api/services/CraftService.java
+++ b/src/main/java/com/loofah/graph/api/services/CraftService.java
@@ -8,25 +8,30 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 @Component
 public class CraftService {
 
-    private DataRetriever dataRetriever;
+    private final DataRetriever dataRetriever;
 
     @Autowired
-    public CraftService(DataRetriever dataRetriever) {
+    public CraftService(final DataRetriever dataRetriever) {
         this.dataRetriever = dataRetriever;
     }
 
-    public Craft getById(String id) {
-        return dataRetriever.getCraftById(id).orElseThrow(() -> new DataNotFoundException("no craft found with id ["+id+"]"));
+    public Craft getById(final String id) {
+        return dataRetriever.getCraftById(id).orElseThrow(() -> new DataNotFoundException("no craft found with id [" + id + "]"));
     }
 
-    public Craft getByTitle(String title) {
-        return dataRetriever.getCraftByTitle(title).orElseThrow(() -> new DataNotFoundException("no craft found with title ["+title+"]"));
+    public Craft getByTitle(final String title) {
+        return dataRetriever.getCraftByTitle(title).orElseThrow(() -> new DataNotFoundException("no craft found with title [" + title + "]"));
     }
 
     public List<Craft> getAll() {
-        return dataRetriever.getAllCrafts();
+        return dataRetriever.getAllCrafts()
+                .stream()
+                .sorted()
+                .collect(toList());
     }
 }

--- a/src/main/java/com/loofah/graph/api/services/GradeService.java
+++ b/src/main/java/com/loofah/graph/api/services/GradeService.java
@@ -8,25 +8,30 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 @Component
 public class GradeService {
 
-    private DataRetriever dataRetriever;
+    private final DataRetriever dataRetriever;
 
     @Autowired
-    public GradeService(DataRetriever dataRetriever) {
+    public GradeService(final DataRetriever dataRetriever) {
         this.dataRetriever = dataRetriever;
     }
 
-    public Grade getById(String id) {
-        return dataRetriever.getGradeById(id).orElseThrow(() -> new DataNotFoundException("no grade found with id ["+id+"]"));
+    public Grade getById(final String id) {
+        return dataRetriever.getGradeById(id).orElseThrow(() -> new DataNotFoundException("no grade found with id [" + id + "]"));
     }
 
-    public Grade getByTitle(String title) {
-        return dataRetriever.getGradeByTitle(title).orElseThrow(() -> new DataNotFoundException("no grade found with title ["+title+"]"));
+    public Grade getByTitle(final String title) {
+        return dataRetriever.getGradeByTitle(title).orElseThrow(() -> new DataNotFoundException("no grade found with title [" + title + "]"));
     }
 
     public List<Grade> getAll() {
-        return dataRetriever.getAllGrades();
+        return dataRetriever.getAllGrades()
+                .stream()
+                .sorted()
+                .collect(toList());
     }
 }

--- a/src/test/java/com/loofah/graph/api/services/CategoryServiceTest.java
+++ b/src/test/java/com/loofah/graph/api/services/CategoryServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -28,10 +29,10 @@ public class CategoryServiceTest {
     @Test
     public void getById_whenCategoryExists_thenReturnCategory() {
 
-        Category expectedCategory = Category.builder().build();
+        final Category expectedCategory = Category.builder().build();
         when(dataRetriever.getCategoryById("1")).thenReturn(Optional.of(expectedCategory));
 
-        Category actualCategory = categoryService.getById("1");
+        final Category actualCategory = categoryService.getById("1");
 
         assertEquals(expectedCategory, actualCategory);
     }
@@ -46,11 +47,31 @@ public class CategoryServiceTest {
     @Test
     public void getAll() {
 
-        List<Category> expectedCategories = Collections.singletonList(Category.builder().build());
+        final List<Category> expectedCategories = Collections.singletonList(Category.builder().build());
         when(dataRetriever.getAllCategories()).thenReturn(expectedCategories);
 
-        List<Category> actualCategory = categoryService.getAll();
+        final List<Category> actualCategory = categoryService.getAll();
 
         assertEquals(expectedCategories, actualCategory);
+    }
+
+    @Test
+    public void getAll_sortsCategories() {
+
+        final List<Category> sortedCategories = asList(
+                Category.builder().withTitle("aardvark").build(),
+                Category.builder().withTitle("bear").build(),
+                Category.builder().withTitle("butterfly").build()
+        );
+        final List<Category> unsortedCategories = asList(
+                Category.builder().withTitle("butterfly").build(),
+                Category.builder().withTitle("bear").build(),
+                Category.builder().withTitle("aardvark").build()
+        );
+        when(dataRetriever.getAllCategories()).thenReturn(unsortedCategories);
+
+        final List<Category> actualCategory = categoryService.getAll();
+
+        assertEquals(sortedCategories, actualCategory);
     }
 }

--- a/src/test/java/com/loofah/graph/api/services/CraftServiceTest.java
+++ b/src/test/java/com/loofah/graph/api/services/CraftServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -28,10 +29,10 @@ public class CraftServiceTest {
     @Test
     public void getById_whenCraftExists_thenReturnCraft() {
 
-        Craft expectedCraft = Craft.builder().build();
+        final Craft expectedCraft = Craft.builder().build();
         when(dataRetriever.getCraftById("id")).thenReturn(Optional.of(expectedCraft));
 
-        Craft actualCraft = craftService.getById("id");
+        final Craft actualCraft = craftService.getById("id");
 
         assertEquals(expectedCraft, actualCraft);
     }
@@ -46,12 +47,32 @@ public class CraftServiceTest {
     @Test
     public void getAll() {
 
-        List<Craft> expectedCrafts = Collections.singletonList(Craft.builder().build());
+        final List<Craft> expectedCrafts = Collections.singletonList(Craft.builder().build());
         when(dataRetriever.getAllCrafts()).thenReturn(expectedCrafts);
 
-        List<Craft> actualCrafts = craftService.getAll();
+        final List<Craft> actualCrafts = craftService.getAll();
 
         assertEquals(expectedCrafts, actualCrafts);
+    }
+
+    @Test
+    public void getAll_sortsCrafts() {
+
+        final List<Craft> sortedCrafts = asList(
+                Craft.builder().withTitle("apple").build(),
+                Craft.builder().withTitle("blackberry").build(),
+                Craft.builder().withTitle("blackcurrant").build()
+        );
+        final List<Craft> unsortedCrafts = asList(
+                Craft.builder().withTitle("blackcurrant").build(),
+                Craft.builder().withTitle("blackberry").build(),
+                Craft.builder().withTitle("apple").build()
+        );
+        when(dataRetriever.getAllCrafts()).thenReturn(unsortedCrafts);
+
+        final List<Craft> actualCrafts = craftService.getAll();
+
+        assertEquals(sortedCrafts, actualCrafts);
     }
 
 }

--- a/src/test/java/com/loofah/graph/api/services/GradeServiceTest.java
+++ b/src/test/java/com/loofah/graph/api/services/GradeServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -28,10 +29,10 @@ public class GradeServiceTest {
     @Test
     public void getById_whenGradeExists_thenReturnGrade() {
 
-        Grade expectedGrade = Grade.builder().build();
+        final Grade expectedGrade = Grade.builder().build();
         when(dataRetriever.getGradeById("id")).thenReturn(Optional.of(expectedGrade));
 
-        Grade actualGrade = gradeService.getById("id");
+        final Grade actualGrade = gradeService.getById("id");
 
         assertEquals(expectedGrade, actualGrade);
     }
@@ -46,11 +47,31 @@ public class GradeServiceTest {
     @Test
     public void getAll() {
 
-        List<Grade> expectedGrades = Collections.singletonList(Grade.builder().build());
+        final List<Grade> expectedGrades = Collections.singletonList(Grade.builder().build());
         when(dataRetriever.getAllGrades()).thenReturn(expectedGrades);
 
-        List<Grade> actualGrades = gradeService.getAll();
+        final List<Grade> actualGrades = gradeService.getAll();
 
         assertEquals(expectedGrades, actualGrades);
+    }
+
+    @Test
+    public void getAll_sortsGrades() {
+
+        final List<Grade> sortedGrades = asList(
+                Grade.builder().withTitle("analystDeveloper").build(),
+                Grade.builder().withTitle("developer").build(),
+                Grade.builder().withTitle("seniorDeveloper").build()
+        );
+        final List<Grade> unsortedGrades = asList(
+                Grade.builder().withTitle("seniorDeveloper").build(),
+                Grade.builder().withTitle("developer").build(),
+                Grade.builder().withTitle("analystDeveloper").build()
+        );
+        when(dataRetriever.getAllGrades()).thenReturn(unsortedGrades);
+
+        final List<Grade> actualGrades = gradeService.getAll();
+
+        assertEquals(sortedGrades, actualGrades);
     }
 }


### PR DESCRIPTION
This commit ensures that the API returns grades, categories and crafts
in the natural sort order from their respective endpoints. This is
alphabetical order for categories and crafts, and seniority order for
grades.